### PR TITLE
Fix confusion of Cygwin PID and Windows PID

### DIFF
--- a/plugins/ssh.ps1
+++ b/plugins/ssh.ps1
@@ -34,7 +34,7 @@ function Get-SshAgent() {
             Write-Host "Killing stale ssh agents."
         }
         Get-Process | Where-Object { $_.Name -eq 'ssh-agent' } | Stop-Process
-         Remove-Item $agentEnvFile
+        Remove-Item $agentEnvFile
     }
 
     return 0

--- a/plugins/ssh.ps1
+++ b/plugins/ssh.ps1
@@ -30,7 +30,9 @@ function Get-SshAgent() {
     # We cannot reach non win32-openssh ssh-agent processes. SSH_AUTH_SOCK is invalid. 
     # Kill these processes and remove the agentEnvFile.
     if (Test-Path $agentEnvFile) {
-         Write-Host "Killing the stale agents."
+        if ($Verbose) {
+            Write-Host "Killing stale ssh agents."
+        }
          get-process | where-object { $_.Name -eq 'ssh-agent' } | kill
          Remove-Item $agentEnvFile
     }

--- a/plugins/ssh.ps1
+++ b/plugins/ssh.ps1
@@ -18,7 +18,7 @@ function Import-AgentEnv() {
 function Get-SshAgent() {
     $agentPid = $env:SSH_AGENT_PID
     if ($agentPid) {
-        ssh-add -l 2>&1 > $null
+        (& ssh-add -l) | Out-Null
         $code = $lastexitcode
         if ($code -lt 2) {
             return $agentPid

--- a/plugins/ssh.ps1
+++ b/plugins/ssh.ps1
@@ -19,7 +19,7 @@ function Get-SshAgent() {
     $agentPid = $env:SSH_AGENT_PID
     if ($agentPid) {
         (& ssh-add -l) | Out-Null
-        if ($code -lt 2) {
+        if ($LASTEXITCODE -lt 2) {
             return $agentPid
         } else {
            $env:SSH_AGENT_PID = $null

--- a/plugins/ssh.ps1
+++ b/plugins/ssh.ps1
@@ -19,7 +19,6 @@ function Get-SshAgent() {
     $agentPid = $env:SSH_AGENT_PID
     if ($agentPid) {
         (& ssh-add -l) | Out-Null
-        $code = $lastexitcode
         if ($code -lt 2) {
             return $agentPid
         } else {

--- a/plugins/ssh.ps1
+++ b/plugins/ssh.ps1
@@ -33,7 +33,7 @@ function Get-SshAgent() {
         if ($Verbose) {
             Write-Host "Killing stale ssh agents."
         }
-         get-process | where-object { $_.Name -eq 'ssh-agent' } | kill
+        Get-Process | Where-Object { $_.Name -eq 'ssh-agent' } | Stop-Process
          Remove-Item $agentEnvFile
     }
 


### PR DESCRIPTION
The ssh-agent returns a cygwin PID which cannot be used with Get-Process and the Get-SshAgent function doesn't return running processes. We fix this by checking the return value of ssh-add -l